### PR TITLE
Fix Optional check in AlunoController

### DIFF
--- a/src/main/java/br/edu/ifsp/pep/api/controller/AlunoController.java
+++ b/src/main/java/br/edu/ifsp/pep/api/controller/AlunoController.java
@@ -85,7 +85,7 @@ public class AlunoController {
     public ResponseEntity<Aluno> atualizarCPF(@RequestParam("cpf") String cpf, @PathVariable Integer matricula) {
         Optional<Aluno> alunoOptional = alunoService.acharPorMatricula(matricula);
 
-        if (alunoOptional == null) {
+        if (alunoOptional.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
 


### PR DESCRIPTION
## Summary
- fix `alunoOptional` null check when patching CPF

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68403cb90bf88322a42478a1145dac7a